### PR TITLE
Fix web tool - UserLocation

### DIFF
--- a/src/types/tools.rs
+++ b/src/types/tools.rs
@@ -55,13 +55,13 @@ pub struct UserLocation {
     /// The type of location approximation
     pub r#type: UserLocationType,
     /// Free text input for the city of the user, e.g. `San Francisco`.
-    pub city: String,
+    pub city: Option<String>,
     /// The two-letter [ISO country code](https://en.wikipedia.org/wiki/ISO_3166-1) of the user, e.g. `US`.
-    pub country: String,
+    pub country: Option<String>,
     /// Free text input for the region of the user, e.g. `California`.
-    pub region: String,
+    pub region: Option<String>,
     /// The [IANA timezone](https://timeapi.io/documentation/iana-timezones) of the user, e.g. `America/Los_Angeles`.
-    pub timezone: String,
+    pub timezone: Option<String>,
 }
 
 /// The type of location approximation


### PR DESCRIPTION
The UserLocation struct is implemented incorrectly. The Strings should be wrapped with Option since the API reference specifies that these are optional parameters (and may be unset or null).

As a result of this implementation, the current code will give a decoder error when OpenAI omits one or more of these parameters in a response object. See https://github.com/m1guelpf/openai-responses-rs/issues/1

This PR fixes this issue by wrapping `city`, `country`, `region`, and `timezone` with Option, because they're all optional parameters.

<3