### PR TITLE
Use snake_case on ImageDetail enum choices

### DIFF
--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -182,6 +182,7 @@ pub enum ContentItem {
 
 /// The detail level of the image sent to the model.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ImageDetail {
     #[default]
     Auto,


### PR DESCRIPTION
For some reason, OpenAI's image detail parameter is case-sensitive and will not accept anything capitalized. Currently, all images sent will result in an error.

This PR will make sure ImageDetail perfectly matches OpenAI's lowercase choices.