### PR TITLE
Make `status` field optional in `Reasoning` struct

### DIFF
--- a/src/types/item.rs
+++ b/src/types/item.rs
@@ -395,7 +395,7 @@ pub struct Reasoning {
     /// Reasoning text contents.
     pub summary: Vec<ReasoningSummary>,
     /// The status of the item.
-    pub status: ReasoningStatus,
+    pub status: Option<ReasoningStatus>,
 }
 
 /// Reasoning text contents.


### PR DESCRIPTION
On a synchronous (non-streaming) call to the responses API, the reasoning item does not necessarily return a status item. From the docs:

The status of the item. One of in_progress, completed, or incomplete. Populated when items are returned via API.

I can't say for completely certain, but I think this means when you obtain items from the various input items API, not from the main response.

In either case, here is an example response I got from the API:

```json
  "output": [
    {
      "id": "rs_689d134311248197940603462818bef80b2bf3335b68afbc",
      "type": "reasoning",
      "summary": []
    },
    {
      "id": "msg_689d13461f048197b9cfde83adf41f130b2bf3335b68afbc",
      "type": "message",
      "status": "completed",
      "content": [
        {
          "type": "output_text",
          "annotations": [],
          "logprobs": [],
          "text": "..."
        }
      ],
      "role": "assistant"
    }
  ],
```